### PR TITLE
create one matte at a time, always red color

### DIFF
--- a/create_mattes_from_colored_mattes.py
+++ b/create_mattes_from_colored_mattes.py
@@ -252,8 +252,12 @@ for frame in range(matte_start_frame, matte_end_frame + 1, args.increment):
         matte_colors = get_matte_colors(image)    
 
         for element in bw_matte_elements:
-            element_matte_path = rf'{matte_path}\{element}'
-            element_color = matte_element_to_color[element]
+            # element_matte_path = rf'{matte_path}\{element}'
+            # element is now part of matte_path
+            element_matte_path = rf'{matte_path}'
+            # element_color = matte_element_to_color[element]
+            # Always look for 'dorothy red' now
+            element_color = matte_element_to_color['dorothy']
             # if that color is in the colormatte for that frame, create a b/w matte matte for the element
             if element_color in matte_colors:
                 matte = get_element_bw_matte_from_colormatte(image, element_color)
@@ -270,7 +274,9 @@ for frame in range(matte_start_frame, matte_end_frame + 1, args.increment):
             # create a black matte using the image width and height of the input images
             black_matte = create_black_matte(IMAGE_WIDTH, IMAGE_HEIGHT)
             # write the black matte
-            element_matte_path = rf'{matte_path}\{element}'
+            # element_matte_path = rf'{matte_path}\{element}'
+            # element is now part of matte_path
+            element_matte_path = rf'{matte_path}'
             
             save_bw_matte(black_matte, element_matte_path, black_matte_filename)
 

--- a/create_mattes_from_colored_mattes.py
+++ b/create_mattes_from_colored_mattes.py
@@ -155,8 +155,9 @@ def create_frame_dict(files):
 parser = argparse.ArgumentParser(description='Create black and white matte for element in color matte.')
 
 # Required parameters
-parser.add_argument('colormatte_path', help='Path to the colormatte files from which to extract black and white mattes')
-parser.add_argument('element', type=str, help='Element that needs a black and white matte')
+parser.add_argument('colormatte_path',
+                     help='Path to the colormatte files from which to extract black and white mattes. The last folder in the path must be the element name.')
+# parser.add_argument('element', type=str, help='Element that needs a black and white matte')
 
 # Optional parameters
 parser.add_argument('-sf', '--start_frame', type=int, help='Start processing at this frame')
@@ -165,7 +166,7 @@ parser.add_argument('-incr', '--increment', type=int, default=1, help='Frame inc
 
 args = parser.parse_args()
 
-bw_matte_element = args.element
+element = os.path.basename(args.colormatte_path)
 
 
 # Get the default frame range from the denoise path
@@ -189,7 +190,7 @@ else:
 
 
 print('colormatte_path', args.colormatte_path)
-print('element', bw_matte_element)
+print('element', element)
 print('start_frame', matte_start_frame)
 print('end_frame', matte_end_frame)
 print('increment', args.increment)


### PR DESCRIPTION
To accommodate XMem2 issues, always look for a red color matte and generate b/w matte one element at a time.

I removed the dependency on the csv file as well.